### PR TITLE
Add workflow to push backend code to hugging face

### DIFF
--- a/.github/workflows/hugging-face.yml
+++ b/.github/workflows/hugging-face.yml
@@ -1,0 +1,30 @@
+name: Upload to Hugging Face Space
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+
+jobs:
+  upload-to-huggingface:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Hugging Face Hub CLI
+        run: pip install -U "huggingface_hub[cli]"
+
+      - name: Upload to Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          huggingface-cli login --token $HF_TOKEN
+          huggingface-cli upload --repo-type space patdel0/dev-digest-backend ./backend/

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Django's command-line utility for administrative tasks."""
+"""Django's command-line utility for administrative tasks"""
 import os
 import sys
 


### PR DESCRIPTION
Closes #68 

This PR creates a GitHub action to sync the GitHub repo with the [Hugging Face application](https://huggingface.co/spaces/patdel0/dev-digest-backend/tree/main).

Not much to do in terms of testing, as this will run only when merged into `main`.
However, I ran a previous version of the action to test the Hugging Face cli tool and `HF_TOKEN` secret value. This previous version was listening just for a push and ran successfully. 

Successful run found here: https://github.com/patdel0/dev-digest/actions/runs/9981847332/job/27586353749
Resulting commit in Hugging Face space: https://huggingface.co/spaces/patdel0/dev-digest-backend/commit/55aebc28cf7520c5f6ee1da6e05a7cdfd79bc841

